### PR TITLE
feat: update hover for GitHub link on the page Case Study

### DIFF
--- a/src/components/pages/case-study/content/content.jsx
+++ b/src/components/pages/case-study/content/content.jsx
@@ -117,15 +117,20 @@ const Content = ({
           {githubUsername && githubRepoName && (
             <Link
               className={clsx(
-                'invisible mt-7 inline-flex items-center rounded-full border border-white p-2 pr-4 opacity-0 transition-[opacity,visibility,border-color] duration-200 hover:border-red',
+                'group invisible mt-7 inline-flex items-center rounded-full border border-white p-2 pr-4 opacity-0 transition-[opacity,visibility,border-color] duration-200 hover:border-blue',
                 githubStars && '!visible !opacity-100'
               )}
               to={getGithubRepoLink(githubUsername, githubRepoName)}
               target="_blank"
               rel="noopener noreferrer"
             >
-              <GithubLogo className="h-7 text-white" aria-hidden />
-              <span className="ml-2 text-xs font-semibold text-white">{githubStars}</span>
+              <GithubLogo
+                className="h-7 text-white duration-200 group-hover:text-blue"
+                aria-hidden
+              />
+              <span className="ml-2 text-xs font-semibold text-white duration-200 group-hover:text-blue">
+                {githubStars}
+              </span>
             </Link>
           )}
           {[


### PR DESCRIPTION
**Describe what changes this pull request brings**
This pull request adds social blue hover on gitHub icon.

**Steps to test**

1. Open the [page](https://deploy-preview-52--pixelpoint-website.netlify.app/case-studies/novu/)
2. Confirm that everything looks and works as expected

**Screenshots**
Blue hover on githib icon
![2022-05-04_20-51-22](https://user-images.githubusercontent.com/75138180/166720826-97d2ecfa-b1f8-4476-bbd7-8f79621a43fb.png)



**References**
