### PR TITLE
feat: add hidden h1 in Hero on Homepage

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -12,6 +12,8 @@ import lgIllustration3 from './images/lg-illustration-3.svg';
 
 const STATE_MACHINE_NAME = 'State Machine';
 const INPUT_NAME = 'Fall Trigger';
+const HEADER =
+  'Pixel Point creative web agency: design and development of JAMStack-based marketing websites';
 
 const firstSectionTitleItems = [
   { value: 'A' },
@@ -138,6 +140,7 @@ const Hero = () => {
     >
       <div className="container grid-gap-x relative grid grid-cols-2 md:block" ref={containerRef}>
         <div className="relative z-10 text-6xl font-normal leading-snug lg:text-[42px] md:mx-auto md:text-4xl sm:text-2xl">
+          <h1 className="absolute -top-[2000px] w-0">{HEADER}</h1>
           <div className="flex h-screen items-center md:block md:h-auto" ref={firstSectionRef}>
             <TitleAnimation
               className="md:max-w-[574px]"


### PR DESCRIPTION
This pull request adds hidden h1 in Hero on Homepage for seo optimization;

[Design]()

**Checklist**:
- [ ] Checked for Pixel Perfect (n/a);
- [x] Checked responsive in BrowserStack ();
- [x] Сhecked size of images/animations/videos (did not push any content of these types);
- [x] Сhecked  for errors in the browser console;
- [x] Сhecked  for linter errors;

<details>
<summary>Screenshot</summary>
Homepage:

![2022-10-14_14-22-11](https://user-images.githubusercontent.com/75138180/195812094-19860e38-1e38-4fed-92c5-1796900c1ad9.png)

</details>


**Steps to test**
1. Open the [page](https://pixelpointwebsite-hiddenh1forseo.gtsb.io/)
2. Confirm that everything looks and works as expected

