### PR TITLE
feat: add attrb playsinline for autoplay video

### DIFF
--- a/content/posts/2022-06-29-web-optimized-video-ffmpeg/index.md
+++ b/content/posts/2022-06-29-web-optimized-video-ffmpeg/index.md
@@ -69,7 +69,7 @@ For better visualization, I am going to show you how applying different options 
 
 The original file size of the video is ~ 26MB and has a 5000x2700 resolution.
 
-<video autoplay muted loop width="800" height="600">
+<video autoplay muted loop playsinline width="800" height="600">
 <source type="video/mp4" src="https://pixel-point-website.s3.amazonaws.com/posts/2022-06-29-web-optimized-video-ffmpeg/hero-an-crf32-best-libx265-3840.mp4" />
 <source type="video/webm" src="https://pixel-point-website.s3.amazonaws.com/posts/2022-06-29-web-optimized-video-ffmpeg/hero-crf-40-3840.webm" />
 </video>


### PR DESCRIPTION
This pull request prevents video from playing on the whole screen on safari/iPhone by adding the missing attribute `playsinline` 