### PR TITLE
fix: ios safari white border on lazy load images

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -153,6 +153,7 @@ const Hero = () => {
               aria-hidden
             >
               <img
+                className="remove-image-loading-visual"
                 src={lgIllustration1}
                 width={468}
                 height={380}

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -180,6 +180,7 @@ const Hero = () => {
               aria-hidden
             >
               <img
+                className="remove-image-loading-visual"
                 src={lgIllustration2}
                 width={590}
                 height={700}
@@ -206,6 +207,7 @@ const Hero = () => {
               aria-hidden
             >
               <img
+                className="remove-image-loading-visual"
                 src={lgIllustration3}
                 width={590}
                 height={766}

--- a/src/components/pages/home/services/services.jsx
+++ b/src/components/pages/home/services/services.jsx
@@ -55,6 +55,7 @@ const Services = () => {
         <div className="mt-14 hidden md:block sm:mt-8" aria-hidden>
           <ImagePlaceholder width={1544} height={658}>
             <img
+              className="remove-image-loading-visual"
               src={lgIllustration1}
               width={1544}
               height={658}
@@ -82,6 +83,7 @@ const Services = () => {
             aria-hidden
           >
             <img
+              className="remove-image-loading-visual"
               src={lgIllustration2}
               width={540}
               height={437}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22,3 +22,4 @@
 @import './safe-paddings.css';
 @import './scrollbar-hidden.css';
 @import './with-link.css';
+@import './remove-image-loading-visual.css';

--- a/src/styles/remove-image-loading-visual.css
+++ b/src/styles/remove-image-loading-visual.css
@@ -1,0 +1,6 @@
+@layer utilities {
+  .remove-image-loading-visual {
+    color: transparent;
+    clip-path: inset(0.5px);
+  }
+}


### PR DESCRIPTION
This PR fix ios safari white border on lazy load images

**Steps to test**
1. Open the [page](https://pixelpointwebsite-safariimagefix.gtsb.io/)