### PR TITLE
Persist AVAL demo proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ yarn-error.log
 .yarn-integrity
 
 .vscode/snipsnap.code-snippets
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,18 @@
   ],
   "rewrites": [
     {
+      "source": "/aval",
+      "destination": "https://aval-demo-ten.vercel.app/aval"
+    },
+    {
+      "source": "/aval/",
+      "destination": "https://aval-demo-ten.vercel.app/aval/"
+    },
+    {
+      "source": "/aval/:path*",
+      "destination": "https://aval-demo-ten.vercel.app/aval/:path*"
+    },
+    {
       "source": "/links/",
       "destination": "https://pixel-point-next.vercel.app/links"
     },


### PR DESCRIPTION
## What changed

- preserve the `/aval`, `/aval/`, and `/aval/:path*` rewrites to the stable `aval-demo-ten.vercel.app` production alias
- ignore local Vercel project metadata

## Why

The live proxy was present only in a manually deployed dirty working tree. A later clean Git deployment of the website could otherwise remove `pixelpoint.io/aval/`.

## Verification

- `vercel.json` parses as valid JSON
- Git-triggered preview `dpl_5qMrCX2hH6EhDXZAJFKcXkHw6bBU` completed successfully
- the live `pixelpoint.io/aval/` response matches the upstream `aval-demo` alias